### PR TITLE
Split tests based on OS

### DIFF
--- a/src/test/java/org/spldev/formula/analysis/javasmt/TestSolvers.java
+++ b/src/test/java/org/spldev/formula/analysis/javasmt/TestSolvers.java
@@ -32,6 +32,7 @@ import org.sosy_lab.java_smt.*;
 import org.sosy_lab.java_smt.SolverContextFactory.*;
 import org.sosy_lab.java_smt.api.*;
 import org.spldev.util.logging.*;
+import org.spldev.util.os.OSType;
 
 public class TestSolvers {
 

--- a/src/test/java/org/spldev/formula/analysis/javasmt/TestSolvers.java
+++ b/src/test/java/org/spldev/formula/analysis/javasmt/TestSolvers.java
@@ -35,15 +35,40 @@ import org.spldev.util.logging.*;
 
 public class TestSolvers {
 
+	private void solversWindows() {
+		testAvailability(Solvers.MATHSAT5);
+		testAvailability(Solvers.PRINCESS);
+		testAvailability(Solvers.SMTINTERPOL);
+		testAvailability(Solvers.Z3);
+	}
+
+	private void solversUnix() {
+		testAvailability(Solvers.BOOLECTOR);
+		testAvailability(Solvers.CVC4);
+		testAvailability(Solvers.MATHSAT5);
+		testAvailability(Solvers.PRINCESS);
+		testAvailability(Solvers.SMTINTERPOL);
+		testAvailability(Solvers.Z3);
+	}
+
+	private void solversMac(){
+		testAvailability(Solvers.PRINCESS);
+		testAvailability(Solvers.SMTINTERPOL);
+		testAvailability(Solvers.Z3);
+	}
+
 	@Test
 	public void solvers() {
 		try {
-			testAvailability(Solvers.BOOLECTOR);
-			testAvailability(Solvers.CVC4);
-			testAvailability(Solvers.MATHSAT5);
-			testAvailability(Solvers.PRINCESS);
-			testAvailability(Solvers.SMTINTERPOL);
-			testAvailability(Solvers.Z3);
+			if(OSType.IS_UNIX){
+				solversUnix();
+			}
+			if(OSType.IS_MAC){
+				solversMac();
+			}
+			if(OSType.IS_WINDOWS){
+				solversWindows();
+			}
 		} catch (final Exception e) {
 			Logger.logError(e);
 			fail();


### PR DESCRIPTION
Testing availability for all supported solvers should be dependent on the operating system. Some solvers are not supported on all platforms.